### PR TITLE
Wrap table name in quotes for dialect: postgres

### DIFF
--- a/src/utils/getLastMigrationState.ts
+++ b/src/utils/getLastMigrationState.ts
@@ -3,7 +3,7 @@ export default async function getLastMigrationState(sequelize: Sequelize) {
   const [
     lastExecutedMigration,
   ] = await sequelize.query(
-    "SELECT name FROM SequelizeMeta ORDER BY name desc limit 1",
+    `SELECT name FROM "SequelizeMeta" ORDER BY name desc limit 1`,
     { type: "SELECT" }
   );
 
@@ -15,7 +15,7 @@ export default async function getLastMigrationState(sequelize: Sequelize) {
   const [
     lastMigration,
   ] = await sequelize.query(
-    `SELECT state FROM SequelizeMetaMigrations where revision = '${lastRevision}'`,
+    `SELECT state FROM "SequelizeMetaMigrations" where revision = '${lastRevision}'`,
     { type: "SELECT" }
   );
   return lastMigration ? lastMigration["state"] : undefined;


### PR DESCRIPTION
There is known issue with postresql.
When table name is not wrapped in double quotes - postgres tries to find name in lower case.
'SELECT name FROM SequelizeMeta ORDER BY name desc limit 1' shows an error: relation "sequelizemeta" does not exist. But SequelizeMeta table exists.